### PR TITLE
Resolve only Public DNS Zones

### DIFF
--- a/yandex/provider.go
+++ b/yandex/provider.go
@@ -74,7 +74,7 @@ func (p *DNSProvider) zone(zone string) (*dnsProto.DnsZone, error) {
 	for iterator.Next() {
 		value := iterator.Value()
 
-		if value.Zone == zone {
+		if value.Zone == zone && value.PublicVisibility != nil {
 			return value, nil
 		}
 	}


### PR DESCRIPTION
In some cases there are more than one DNS Zones with provided DNS Zone name, thus we need to create DNS Challenge record only in Public DNS Zone, skipping Internal DNS Zones

Ref: https://cloud.yandex.com/en/docs/dns/api-ref/DnsZone/